### PR TITLE
多言語文字起こし精度向上のためのtwo-pass transcription機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Transcription experiment output
+transcribe_experiment/output/

--- a/transcribe_experiment/CLAUDE.md
+++ b/transcribe_experiment/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A YAML-driven experiment runner that compares transcription accuracy across multiple STT services for the same audio file. Each "run" in `config.yaml` defines a service + settings combination; results are saved per-run and aggregated into a comparison report.
+
+## Commands
+
+```bash
+# Dry run — shows which experiments would execute
+python run_experiment.py --dry-run
+
+# Run all experiments
+python run_experiment.py
+
+# Filter by service (comma-separated)
+python run_experiment.py --service faster_whisper,elevenlabs
+
+# Filter by run ID (comma-separated)
+python run_experiment.py --run-ids fw-ja-prompted,gpt4o-auto
+
+# Reuse audio chunks from a prior run (skips ffmpeg splitting)
+python run_experiment.py --skip-split
+```
+
+## Architecture
+
+`run_experiment.py` is the CLI entry point. It loads `config.yaml`, resolves API keys, optionally splits the audio, then runs each experiment sequentially.
+
+**Service abstraction:** Each STT provider lives in `services/` and extends `BaseSTTService`. The key contract is `transcribe_chunk(chunk_path, settings) -> str`. A service's `needs_splitting` flag controls whether it receives split chunks or the full file.
+
+**Audio splitting:** `audio_splitter.py` uses `ffmpeg -c copy` (stream copy, no re-encode). Only services with `needs_splitting = True` (currently just OpenAI due to its 25MB limit) receive chunks; others get the original file.
+
+**Comparison output:** `comparison.py` generates `summary.tsv` (machine-readable) and `comparison.md` (human-readable) from all run results.
+
+**Auth resolution:** API keys come from env vars (`FASTER_WHISPER_API_KEY`, `OPENAI_API_KEY`, `ELEVENLABS_API_KEY`). faster-whisper falls back to `kubectl` secret lookup. Auth is only resolved for services actually used in the selected runs.
+
+## Adding a New Experiment Run
+
+Add an entry to the `runs` list in `config.yaml`. No code changes needed. The `settings` dict is passed through to the service's `transcribe_chunk` as-is.
+
+## Adding a New STT Service
+
+1. Create `services/<name>.py` implementing `BaseSTTService.transcribe_chunk`
+2. Register it in `services/__init__.py` `SERVICE_REGISTRY`
+3. Add auth resolution in `run_experiment.py:resolve_auth`
+
+## Dependencies
+
+All already installed — no pip install needed: `httpx`, `pyyaml`, system `ffmpeg`.

--- a/transcribe_experiment/audio_splitter.py
+++ b/transcribe_experiment/audio_splitter.py
@@ -1,0 +1,128 @@
+import glob
+import json
+import math
+import os
+import subprocess
+import tempfile
+
+
+def get_audio_duration(file_path: str) -> float:
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
+            "-show_format",
+            file_path,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    info = json.loads(result.stdout)
+    return float(info["format"]["duration"])
+
+
+def split_audio_ffmpeg(
+    file_path: str,
+    chunk_size_mb: int = 20,
+    output_dir: str | None = None,
+) -> list[str]:
+    chunk_size_bytes = chunk_size_mb * 1024 * 1024
+    file_size = os.path.getsize(file_path)
+
+    if file_size <= chunk_size_bytes:
+        return [file_path]
+
+    duration = get_audio_duration(file_path)
+    num_chunks = math.ceil(file_size / chunk_size_bytes)
+    chunk_duration = duration / num_chunks
+
+    if output_dir is None:
+        output_dir = os.path.join(os.path.dirname(file_path), "audio_chunks")
+    os.makedirs(output_dir, exist_ok=True)
+
+    ext = os.path.splitext(file_path)[1]
+    chunk_paths = []
+
+    for i in range(num_chunks):
+        start = i * chunk_duration
+        chunk_path = os.path.join(output_dir, f"chunk_{i:03d}{ext}")
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-ss",
+            str(start),
+            "-t",
+            str(chunk_duration),
+            "-i",
+            file_path,
+            "-c",
+            "copy",
+            chunk_path,
+        ]
+        subprocess.run(cmd, capture_output=True, check=True)
+        chunk_paths.append(chunk_path)
+        print(f"  Split chunk {i + 1}/{num_chunks}: {chunk_path}")
+
+    return chunk_paths
+
+
+def split_audio_by_duration(
+    file_path: str,
+    segment_seconds: int = 30,
+    output_dir: str | None = None,
+) -> list[str]:
+    if output_dir is None:
+        output_dir = os.path.join(os.path.dirname(file_path), "segments")
+    os.makedirs(output_dir, exist_ok=True)
+
+    ext = os.path.splitext(file_path)[1]
+    pattern = os.path.join(output_dir, f"segment_%03d{ext}")
+
+    subprocess.run(
+        [
+            "ffmpeg", "-y",
+            "-i", file_path,
+            "-f", "segment",
+            "-segment_time", str(segment_seconds),
+            "-c", "copy",
+            "-reset_timestamps", "1",
+            pattern,
+        ],
+        capture_output=True,
+        check=True,
+    )
+
+    paths = sorted(glob.glob(os.path.join(output_dir, f"segment_*{ext}")))
+    return paths
+
+
+def concat_audio_files(file_paths: list[str], output_path: str) -> str:
+    if len(file_paths) == 1:
+        return file_paths[0]
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        for p in file_paths:
+            f.write(f"file '{p}'\n")
+        list_path = f.name
+
+    try:
+        subprocess.run(
+            [
+                "ffmpeg", "-y",
+                "-f", "concat",
+                "-safe", "0",
+                "-i", list_path,
+                "-c", "copy",
+                output_path,
+            ],
+            capture_output=True,
+            check=True,
+        )
+    finally:
+        os.unlink(list_path)
+
+    return output_path

--- a/transcribe_experiment/comparison.py
+++ b/transcribe_experiment/comparison.py
@@ -1,0 +1,108 @@
+import csv
+import os
+from collections import Counter
+
+from services.base import RunResult
+
+
+def _detect_language_summary(r: RunResult) -> str:
+    detected = [c.detected_language for c in r.chunks if c.detected_language]
+    if not detected:
+        return r.settings.get("language", r.settings.get("language_code", "auto"))
+    counts = Counter(detected)
+    parts = [f"{lang}({n})" for lang, n in counts.most_common()]
+    return "/".join(parts)
+
+
+def generate_comparison(results: list[RunResult], output_dir: str):
+    os.makedirs(output_dir, exist_ok=True)
+    _write_summary_tsv(results, output_dir)
+    _write_comparison_md(results, output_dir)
+    print(f"  Generated summary.tsv and comparison.md in {output_dir}/")
+
+
+def _write_summary_tsv(results: list[RunResult], output_dir: str):
+    path = os.path.join(output_dir, "summary.tsv")
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f, delimiter="\t")
+        writer.writerow(
+            [
+                "run_id",
+                "service",
+                "language",
+                "prompt_hint",
+                "total_seconds",
+                "char_count",
+                "first_200_chars",
+            ]
+        )
+        for r in results:
+            writer.writerow(
+                [
+                    r.run_id,
+                    r.service,
+                    _detect_language_summary(r),
+                    _truncate(r.settings.get("prompt", "(none)"), 40),
+                    r.total_elapsed_seconds,
+                    r.char_count,
+                    _truncate(r.full_text, 200),
+                ]
+            )
+
+
+def _write_comparison_md(results: list[RunResult], output_dir: str):
+    lines: list[str] = []
+    lines.append("# STT Comparison Results\n")
+
+    lines.append("## Overview\n")
+    lines.append(
+        "| Run ID | Service | Language | Time (s) | Chars | Prompt |"
+    )
+    lines.append("|--------|---------|----------|----------|-------|--------|")
+    for r in results:
+        lang = _detect_language_summary(r)
+        prompt = _truncate(r.settings.get("prompt", "-"), 30)
+        lines.append(
+            f"| {r.run_id} | {r.service} | {lang} "
+            f"| {r.total_elapsed_seconds} | {r.char_count} | {prompt} |"
+        )
+    lines.append("")
+
+    lines.append("## Transcription Previews (first 500 chars)\n")
+    for r in results:
+        lines.append(f"### {r.run_id}\n")
+        lines.append("```")
+        lines.append(_truncate(r.full_text, 500))
+        lines.append("```\n")
+
+    chunked = [r for r in results if len(r.chunks) > 1]
+    if chunked:
+        lines.append("## Per-Chunk Comparison\n")
+        max_chunks = max(len(r.chunks) for r in chunked)
+        for ci in range(max_chunks):
+            lines.append(f"### Chunk {ci}\n")
+            for r in chunked:
+                if ci < len(r.chunks):
+                    chunk = r.chunks[ci]
+                    lines.append(f"**{r.run_id}** ({chunk.elapsed_seconds}s):")
+                    lines.append("```")
+                    lines.append(_truncate(chunk.text, 300))
+                    lines.append("```\n")
+
+    lines.append("## Full Text Comparison\n")
+    lines.append(
+        "See each `<run_id>/transcript.txt` for complete transcriptions."
+    )
+
+    path = os.path.join(output_dir, "comparison.md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if not text:
+        return ""
+    text = text.replace("\n", " ")
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "..."

--- a/transcribe_experiment/config.yaml
+++ b/transcribe_experiment/config.yaml
@@ -1,0 +1,106 @@
+audio_file: /Users/murakaminaoya/Downloads/audio_20260507170427.m4a
+
+split:
+  chunk_size_mb: 20
+
+output_dir: ./output
+
+services:
+  faster_whisper:
+    base_url: "http://localhost:8000/v1/audio/transcriptions"
+    model: "deepdml/faster-whisper-large-v3-turbo-ct2"
+  openai_transcribe:
+    model: "gpt-4o-transcribe"
+  elevenlabs:
+    base_url: "https://api.elevenlabs.io/v1/speech-to-text"
+
+runs:
+  - id: fw-ja-prompted
+    service: faster_whisper
+    settings:
+      language: ja
+      prompt: "句読点や読点を適切に付けてください。丁寧な日本語で書き起こしてください。"
+      temperature: 0
+
+  - id: fw-auto
+    service: faster_whisper
+    settings:
+      temperature: 0
+
+  - id: gpt4o-ja-prompted
+    service: openai_transcribe
+    settings:
+      language: ja
+      prompt: "句読点や読点を適切に付けてください。丁寧な日本語で書き起こしてください。"
+
+  - id: gpt4o-auto
+    service: openai_transcribe
+    settings: {}
+
+  - id: el-ja
+    service: elevenlabs
+    settings:
+      model_id: scribe_v1
+      language_code: ja
+
+  - id: el-auto
+    service: elevenlabs
+    settings:
+      model_id: scribe_v1
+
+  - id: fw-multilingual
+    service: faster_whisper
+    settings:
+      prompt: "OK so let me walk you through the current status. We finished the API integration last week. あと、認証のところはまだ残ってるんですけど、来週には対応できると思います。Right, and the dashboard metrics are looking good so far. 对，那个数据分析的部分我们已经完成了。Great, so next steps would be the load testing phase."
+      temperature: 0
+
+  - id: fw-ja-nocond
+    service: faster_whisper
+    settings:
+      language: ja
+      prompt: "句読点や読点を適切に付けてください。丁寧な日本語で書き起こしてください。"
+      temperature: 0
+      condition_on_previous_text: false
+
+  - id: fw-multilingual-nocond
+    service: faster_whisper
+    settings:
+      prompt: "OK so let me walk you through the current status. We finished the API integration last week. あと、認証のところはまだ残ってるんですけど、来週には対応できると思います。Right, and the dashboard metrics are looking good so far. 对，那个数据分析的部分我们已经完成了。Great, so next steps would be the load testing phase."
+      temperature: 0
+      condition_on_previous_text: false
+
+  - id: gpt4o-multilingual
+    service: openai_transcribe
+    settings:
+      prompt: "OK so let me walk you through the current status. We finished the API integration last week. あと、認証のところはまだ残ってるんですけど、来週には対応できると思います。Right, and the dashboard metrics are looking good so far. 对，那个数据分析的部分我们已经完成了。Great, so next steps would be the load testing phase."
+
+  - id: fw-twopass
+    service: two_pass
+    settings:
+      segment_seconds: 30
+      confidence_threshold: 0.7
+      fallback_language: ja
+      pass1:
+        service: faster_whisper
+        settings:
+          temperature: 0
+      pass2:
+        service: faster_whisper
+        settings:
+          temperature: 0
+          prompt: "句読点や読点を適切に付けてください。丁寧な日本語で書き起こしてください。"
+
+  - id: gpt4o-twopass
+    service: two_pass
+    settings:
+      segment_seconds: 30
+      confidence_threshold: 0.7
+      fallback_language: ja
+      pass1:
+        service: faster_whisper
+        settings:
+          temperature: 0
+      pass2:
+        service: openai_transcribe
+        settings:
+          prompt: "句読点や読点を適切に付けてください。丁寧な日本語で書き起こしてください。"

--- a/transcribe_experiment/config.yaml
+++ b/transcribe_experiment/config.yaml
@@ -48,6 +48,24 @@ runs:
     settings:
       model_id: scribe_v1
 
+  - id: el-v2-ja
+    service: elevenlabs
+    settings:
+      model_id: scribe_v2
+      language_code: ja
+
+  - id: el-v2-auto
+    service: elevenlabs
+    settings:
+      model_id: scribe_v2
+
+  - id: el-v2-ja-clean
+    service: elevenlabs
+    settings:
+      model_id: scribe_v2
+      language_code: ja
+      no_verbatim: true
+
   - id: fw-multilingual
     service: faster_whisper
     settings:

--- a/transcribe_experiment/run_experiment.py
+++ b/transcribe_experiment/run_experiment.py
@@ -1,0 +1,299 @@
+import argparse
+import json
+import os
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from audio_splitter import split_audio_ffmpeg
+from comparison import generate_comparison
+from services import RunResult, ChunkResult, create_service
+
+
+def load_config(config_path: str) -> dict:
+    with open(config_path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def resolve_auth(services_config: dict, needed_services: set[str]) -> dict[str, str]:
+    auth: dict[str, str] = {}
+
+    if "faster_whisper" in needed_services:
+        key = os.environ.get("FASTER_WHISPER_API_KEY")
+        if not key:
+            try:
+                result = subprocess.run(
+                    [
+                        "kubectl",
+                        "-n",
+                        "stt-api",
+                        "get",
+                        "secret",
+                        "stt-api-key",
+                        "-o",
+                        "jsonpath={.data.api-key}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=10,
+                )
+                key = subprocess.run(
+                    ["base64", "-d"],
+                    input=result.stdout,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ).stdout.strip()
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                pass
+        if not key:
+            raise ValueError(
+                "faster_whisper API key not found. "
+                "Set FASTER_WHISPER_API_KEY or ensure kubectl access."
+            )
+        auth["faster_whisper"] = key
+
+    if "openai_transcribe" in needed_services:
+        key = os.environ.get("OPENAI_API_KEY")
+        if not key:
+            raise ValueError("OPENAI_API_KEY environment variable is required.")
+        auth["openai_transcribe"] = key
+
+    if "elevenlabs" in needed_services:
+        key = os.environ.get("ELEVENLABS_API_KEY")
+        if not key:
+            raise ValueError("ELEVENLABS_API_KEY environment variable is required.")
+        auth["elevenlabs"] = key
+
+    return auth
+
+
+def filter_runs(
+    runs: list[dict],
+    run_ids: list[str] | None,
+    service_filters: list[str] | None,
+) -> list[dict]:
+    filtered = runs
+    if run_ids:
+        filtered = [r for r in filtered if r["id"] in run_ids]
+    if service_filters:
+        filtered = [r for r in filtered if r["service"] in service_filters]
+    return filtered
+
+
+def execute_run(
+    service,
+    run_cfg: dict,
+    chunk_paths: list[str],
+    original_file: str,
+) -> RunResult:
+    paths = chunk_paths if service.needs_splitting else [original_file]
+
+    chunk_results: list[ChunkResult] = []
+    total_start = time.monotonic()
+
+    for i, path in enumerate(paths):
+        print(f"  [{run_cfg['id']}] chunk {i + 1}/{len(paths)}: {os.path.basename(path)}")
+        chunk_start = time.monotonic()
+        try:
+            text = service.transcribe_chunk(path, run_cfg.get("settings", {}))
+            error = None
+        except Exception as e:
+            text = ""
+            error = str(e)
+            print(f"  [{run_cfg['id']}] ERROR on chunk {i}: {error}")
+
+        elapsed = time.monotonic() - chunk_start
+        chunk_result = ChunkResult(
+            chunk_index=i,
+            chunk_path=path,
+            text=text,
+            elapsed_seconds=round(elapsed, 2),
+            error=error,
+        )
+
+        if hasattr(service, "last_detections") and service.last_detections:
+            from collections import Counter
+            langs = Counter(d["detected_language"] for d in service.last_detections)
+            chunk_result.detected_language = "/".join(
+                f"{lang}({n})" for lang, n in langs.most_common()
+            )
+
+        chunk_results.append(chunk_result)
+
+    total_elapsed = time.monotonic() - total_start
+
+    return RunResult(
+        run_id=run_cfg["id"],
+        service=run_cfg["service"],
+        settings=run_cfg.get("settings", {}),
+        chunks=chunk_results,
+        total_elapsed_seconds=round(total_elapsed, 2),
+    )
+
+
+def save_result(result: RunResult, output_dir: str, audio_file: str):
+    run_dir = os.path.join(output_dir, result.run_id)
+    os.makedirs(run_dir, exist_ok=True)
+
+    with open(os.path.join(run_dir, "transcript.txt"), "w", encoding="utf-8") as f:
+        f.write(result.full_text)
+
+    chunks_dir = os.path.join(run_dir, "chunks")
+    os.makedirs(chunks_dir, exist_ok=True)
+    for chunk in result.chunks:
+        chunk_file = os.path.join(chunks_dir, f"chunk_{chunk.chunk_index:03d}.txt")
+        with open(chunk_file, "w", encoding="utf-8") as f:
+            f.write(chunk.text)
+
+    meta = {
+        "run_id": result.run_id,
+        "service": result.service,
+        "settings": result.settings,
+        "audio_file": audio_file,
+        "total_elapsed_seconds": result.total_elapsed_seconds,
+        "total_char_count": result.char_count,
+        "chunks": [
+            {
+                "chunk_index": c.chunk_index,
+                "chunk_path": c.chunk_path,
+                "elapsed_seconds": c.elapsed_seconds,
+                "char_count": len(c.text),
+                "error": c.error,
+                "detected_language": c.detected_language,
+                "language_probability": c.language_probability,
+            }
+            for c in result.chunks
+        ],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    with open(os.path.join(run_dir, "meta.json"), "w", encoding="utf-8") as f:
+        json.dump(meta, f, ensure_ascii=False, indent=2)
+
+    print(f"  [{result.run_id}] saved to {run_dir}/")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run STT comparison experiments across multiple services"
+    )
+    parser.add_argument(
+        "config", nargs="?", default="config.yaml", help="Path to config YAML"
+    )
+    parser.add_argument(
+        "--run-ids",
+        help="Comma-separated list of run IDs to execute",
+    )
+    parser.add_argument(
+        "--service",
+        help="Comma-separated list of services to run (e.g. faster_whisper,elevenlabs)",
+    )
+    parser.add_argument(
+        "--skip-split",
+        action="store_true",
+        help="Reuse existing audio chunks from a prior run",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would run without executing",
+    )
+    args = parser.parse_args()
+
+    config_path = args.config
+    if not os.path.isabs(config_path):
+        config_path = os.path.join(os.path.dirname(__file__), config_path)
+
+    config = load_config(config_path)
+    audio_file = config["audio_file"]
+    split_cfg = config.get("split", {})
+    output_dir = config.get("output_dir", "./output")
+    if not os.path.isabs(output_dir):
+        output_dir = os.path.join(os.path.dirname(config_path), output_dir)
+
+    run_ids = args.run_ids.split(",") if args.run_ids else None
+    service_filters = args.service.split(",") if args.service else None
+    runs = filter_runs(config["runs"], run_ids, service_filters)
+
+    if not runs:
+        print("No runs matched the filter criteria.")
+        return
+
+    if args.dry_run:
+        print("=== DRY RUN ===")
+        for run in runs:
+            print(f"  {run['id']} ({run['service']}): {run.get('settings', {})}")
+        print(f"\nTotal: {len(runs)} run(s)")
+        return
+
+    if not os.path.exists(audio_file):
+        raise FileNotFoundError(f"Audio file not found: {audio_file}")
+
+    needs_splitting = any(
+        run["service"] == "openai_transcribe" for run in runs
+    )
+    chunks_dir = os.path.join(output_dir, "chunks")
+
+    if needs_splitting and not args.skip_split:
+        print(f"Splitting audio for OpenAI (chunk_size={split_cfg.get('chunk_size_mb', 20)}MB)...")
+        chunk_paths = split_audio_ffmpeg(
+            audio_file,
+            chunk_size_mb=split_cfg.get("chunk_size_mb", 20),
+            output_dir=chunks_dir,
+        )
+        print(f"  Created {len(chunk_paths)} chunk(s)")
+    elif needs_splitting and args.skip_split:
+        chunk_paths = sorted(
+            str(p) for p in Path(chunks_dir).glob("chunk_*")
+        )
+        if not chunk_paths:
+            raise FileNotFoundError(
+                f"No existing chunks found in {chunks_dir}. Run without --skip-split first."
+            )
+        print(f"  Reusing {len(chunk_paths)} existing chunk(s)")
+    else:
+        chunk_paths = []
+
+    needed_services = {r["service"] for r in runs}
+    for run_cfg in runs:
+        if run_cfg["service"] == "two_pass":
+            s = run_cfg.get("settings", {})
+            if "pass1" in s:
+                needed_services.add(s["pass1"]["service"])
+            if "pass2" in s:
+                needed_services.add(s["pass2"]["service"])
+    needed_services.discard("two_pass")
+    auth = resolve_auth(config.get("services", {}), needed_services)
+    services_config = config.get("services", {})
+
+    results: list[RunResult] = []
+    print(f"\nRunning {len(runs)} experiment(s)...\n")
+
+    for run_cfg in runs:
+        print(f"--- {run_cfg['id']} ({run_cfg['service']}) ---")
+        service = create_service(
+            run_cfg["service"], services_config,
+            auth.get(run_cfg["service"], ""),
+            auth=auth,
+        )
+        if hasattr(service, "output_dir"):
+            service.output_dir = os.path.join(output_dir, run_cfg["id"])
+        result = execute_run(service, run_cfg, chunk_paths, audio_file)
+        save_result(result, output_dir, audio_file)
+        results.append(result)
+        print(
+            f"  Done: {result.total_elapsed_seconds}s, "
+            f"{result.char_count} chars\n"
+        )
+
+    if results:
+        generate_comparison(results, output_dir)
+        print(f"\nAll done. Results in {output_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/transcribe_experiment/services/__init__.py
+++ b/transcribe_experiment/services/__init__.py
@@ -1,0 +1,30 @@
+from .base import BaseSTTService, ChunkResult, RunResult
+from .elevenlabs import ElevenLabsService
+from .faster_whisper import FasterWhisperService
+from .openai_transcribe import OpenAITranscribeService
+from .two_pass import TwoPassService
+
+SERVICE_REGISTRY: dict[str, type[BaseSTTService]] = {
+    "faster_whisper": FasterWhisperService,
+    "openai_transcribe": OpenAITranscribeService,
+    "elevenlabs": ElevenLabsService,
+    "two_pass": TwoPassService,
+}
+
+
+def create_service(
+    name: str,
+    services_config: dict,
+    api_key: str,
+    *,
+    auth: dict | None = None,
+) -> BaseSTTService:
+    cls = SERVICE_REGISTRY[name]
+    if name == "two_pass":
+        return cls(
+            config=services_config.get(name, {}),
+            api_key="",
+            services_config=services_config,
+            auth=auth or {},
+        )
+    return cls(config=services_config.get(name, {}), api_key=api_key)

--- a/transcribe_experiment/services/base.py
+++ b/transcribe_experiment/services/base.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ChunkResult:
+    chunk_index: int
+    chunk_path: str
+    text: str
+    elapsed_seconds: float
+    error: str | None = None
+    detected_language: str | None = None
+    language_probability: float | None = None
+
+
+@dataclass
+class RunResult:
+    run_id: str
+    service: str
+    settings: dict
+    chunks: list[ChunkResult]
+    total_elapsed_seconds: float
+    full_text: str = ""
+
+    def __post_init__(self):
+        if not self.full_text:
+            self.full_text = "\n".join(c.text for c in self.chunks if c.text)
+
+    @property
+    def char_count(self) -> int:
+        return len(self.full_text)
+
+
+class BaseSTTService:
+    needs_splitting: bool = True
+
+    def __init__(self, config: dict, api_key: str):
+        self.config = config
+        self.api_key = api_key
+
+    def transcribe_chunk(self, chunk_path: str, settings: dict) -> str:
+        raise NotImplementedError
+
+    def transcribe_chunk_detailed(self, chunk_path: str, settings: dict) -> dict:
+        text = self.transcribe_chunk(chunk_path, settings)
+        return {"text": text, "language": None, "language_probability": None}

--- a/transcribe_experiment/services/elevenlabs.py
+++ b/transcribe_experiment/services/elevenlabs.py
@@ -1,0 +1,58 @@
+import os
+
+import httpx
+
+from .base import BaseSTTService
+
+
+class ElevenLabsService(BaseSTTService):
+    needs_splitting = False
+
+    def transcribe_chunk(self, chunk_path: str, settings: dict) -> str:
+        url = self.config.get(
+            "base_url", "https://api.elevenlabs.io/v1/speech-to-text"
+        )
+
+        data: dict[str, str] = {
+            "model_id": settings.get("model_id", "scribe_v1"),
+        }
+        if settings.get("language_code"):
+            data["language_code"] = settings["language_code"]
+
+        with open(chunk_path, "rb") as f:
+            response = httpx.post(
+                url,
+                data=data,
+                files={"file": (os.path.basename(chunk_path), f, "audio/mp4")},
+                headers={"xi-api-key": self.api_key},
+                timeout=600.0,
+            )
+        response.raise_for_status()
+        return response.json()["text"]
+
+    def transcribe_chunk_detailed(self, chunk_path: str, settings: dict) -> dict:
+        url = self.config.get(
+            "base_url", "https://api.elevenlabs.io/v1/speech-to-text"
+        )
+
+        data: dict[str, str] = {
+            "model_id": settings.get("model_id", "scribe_v1"),
+        }
+        if settings.get("language_code"):
+            data["language_code"] = settings["language_code"]
+
+        with open(chunk_path, "rb") as f:
+            response = httpx.post(
+                url,
+                data=data,
+                files={"file": (os.path.basename(chunk_path), f, "audio/mp4")},
+                headers={"xi-api-key": self.api_key},
+                timeout=600.0,
+            )
+        response.raise_for_status()
+        body = response.json()
+        return {
+            "text": body.get("text", ""),
+            "language": body.get("language_code"),
+            "language_probability": body.get("language_probability"),
+        }

--- a/transcribe_experiment/services/elevenlabs.py
+++ b/transcribe_experiment/services/elevenlabs.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import httpx
@@ -8,16 +9,24 @@ from .base import BaseSTTService
 class ElevenLabsService(BaseSTTService):
     needs_splitting = False
 
-    def transcribe_chunk(self, chunk_path: str, settings: dict) -> str:
-        url = self.config.get(
-            "base_url", "https://api.elevenlabs.io/v1/speech-to-text"
-        )
-
+    def _build_form_data(self, settings: dict) -> dict[str, str]:
         data: dict[str, str] = {
             "model_id": settings.get("model_id", "scribe_v1"),
         }
         if settings.get("language_code"):
             data["language_code"] = settings["language_code"]
+        if settings.get("no_verbatim") is not None:
+            data["no_verbatim"] = str(settings["no_verbatim"]).lower()
+        if settings.get("keyterms"):
+            data["keyterms"] = json.dumps(settings["keyterms"])
+        return data
+
+    def transcribe_chunk(self, chunk_path: str, settings: dict) -> str:
+        url = self.config.get(
+            "base_url", "https://api.elevenlabs.io/v1/speech-to-text"
+        )
+
+        data = self._build_form_data(settings)
 
         with open(chunk_path, "rb") as f:
             response = httpx.post(
@@ -35,11 +44,7 @@ class ElevenLabsService(BaseSTTService):
             "base_url", "https://api.elevenlabs.io/v1/speech-to-text"
         )
 
-        data: dict[str, str] = {
-            "model_id": settings.get("model_id", "scribe_v1"),
-        }
-        if settings.get("language_code"):
-            data["language_code"] = settings["language_code"]
+        data = self._build_form_data(settings)
 
         with open(chunk_path, "rb") as f:
             response = httpx.post(

--- a/transcribe_experiment/services/faster_whisper.py
+++ b/transcribe_experiment/services/faster_whisper.py
@@ -1,0 +1,64 @@
+import os
+
+import httpx
+
+from .base import BaseSTTService
+
+
+class FasterWhisperService(BaseSTTService):
+    needs_splitting = False
+
+    def transcribe_chunk(self, chunk_path: str, settings: dict) -> str:
+        url = self.config["base_url"]
+        model = self.config["model"]
+
+        data: dict[str, str] = {"model": model}
+        if settings.get("language"):
+            data["language"] = settings["language"]
+        if settings.get("prompt"):
+            data["prompt"] = settings["prompt"]
+        if settings.get("temperature") is not None:
+            data["temperature"] = str(settings["temperature"])
+        if "condition_on_previous_text" in settings:
+            data["condition_on_previous_text"] = str(settings["condition_on_previous_text"]).lower()
+
+        with open(chunk_path, "rb") as f:
+            response = httpx.post(
+                url,
+                data=data,
+                files={"file": (os.path.basename(chunk_path), f, "audio/mp4")},
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=600.0,
+            )
+        response.raise_for_status()
+        return response.json()["text"]
+
+    def transcribe_chunk_detailed(self, chunk_path: str, settings: dict) -> dict:
+        url = self.config["base_url"]
+        model = self.config["model"]
+
+        data: dict[str, str] = {"model": model, "response_format": "verbose_json"}
+        if settings.get("language"):
+            data["language"] = settings["language"]
+        if settings.get("prompt"):
+            data["prompt"] = settings["prompt"]
+        if settings.get("temperature") is not None:
+            data["temperature"] = str(settings["temperature"])
+        if "condition_on_previous_text" in settings:
+            data["condition_on_previous_text"] = str(settings["condition_on_previous_text"]).lower()
+
+        with open(chunk_path, "rb") as f:
+            response = httpx.post(
+                url,
+                data=data,
+                files={"file": (os.path.basename(chunk_path), f, "audio/mp4")},
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=600.0,
+            )
+        response.raise_for_status()
+        body = response.json()
+        return {
+            "text": body.get("text", ""),
+            "language": body.get("language"),
+            "language_probability": None,
+        }

--- a/transcribe_experiment/services/openai_transcribe.py
+++ b/transcribe_experiment/services/openai_transcribe.py
@@ -1,0 +1,30 @@
+import os
+
+import httpx
+
+from .base import BaseSTTService
+
+
+class OpenAITranscribeService(BaseSTTService):
+    needs_splitting = True
+
+    def transcribe_chunk(self, chunk_path: str, settings: dict) -> str:
+        url = "https://api.openai.com/v1/audio/transcriptions"
+        model = self.config.get("model", "gpt-4o-transcribe")
+
+        data: dict[str, str] = {"model": model}
+        if settings.get("language"):
+            data["language"] = settings["language"]
+        if settings.get("prompt"):
+            data["prompt"] = settings["prompt"]
+
+        with open(chunk_path, "rb") as f:
+            response = httpx.post(
+                url,
+                data=data,
+                files={"file": (os.path.basename(chunk_path), f, "audio/mp4")},
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=300.0,
+            )
+        response.raise_for_status()
+        return response.json()["text"]

--- a/transcribe_experiment/services/two_pass.py
+++ b/transcribe_experiment/services/two_pass.py
@@ -1,0 +1,174 @@
+import json
+import os
+from itertools import groupby
+
+from audio_splitter import concat_audio_files, split_audio_by_duration
+
+from .base import BaseSTTService
+
+LANGUAGE_ALIASES = {
+    "japanese": "ja",
+    "english": "en",
+    "chinese": "zh",
+    "korean": "ko",
+    "french": "fr",
+    "german": "de",
+    "spanish": "es",
+    "portuguese": "pt",
+    "italian": "it",
+    "russian": "ru",
+    "dutch": "nl",
+}
+
+
+def normalize_language_code(lang: str | None) -> str | None:
+    if lang is None:
+        return None
+    lang = lang.strip().lower()
+    return LANGUAGE_ALIASES.get(lang, lang)
+
+
+def inject_language_hint(settings: dict, language: str, service_name: str) -> dict:
+    patched = dict(settings)
+    if service_name == "elevenlabs":
+        patched["language_code"] = language
+    else:
+        patched["language"] = language
+    return patched
+
+
+class TwoPassService(BaseSTTService):
+    needs_splitting = False
+
+    def __init__(self, config: dict, api_key: str, *, services_config: dict, auth: dict):
+        super().__init__(config, api_key)
+        self.services_config = services_config
+        self.auth = auth
+        self.output_dir: str | None = None
+        self._pass1_service = None
+        self._pass2_service = None
+        self._last_detections: list[dict] = []
+
+    def _get_service(self, service_name: str) -> BaseSTTService:
+        from . import create_service
+        return create_service(service_name, self.services_config, self.auth[service_name])
+
+    @property
+    def last_detections(self) -> list[dict]:
+        return self._last_detections
+
+    def _ensure_services(self, settings: dict):
+        if self._pass1_service is None:
+            pass1_cfg = settings["pass1"]
+            self._pass1_service = self._get_service(pass1_cfg["service"])
+            self._pass1_name = pass1_cfg["service"]
+        if self._pass2_service is None:
+            pass2_cfg = settings["pass2"]
+            self._pass2_service = self._get_service(pass2_cfg["service"])
+            self._pass2_name = pass2_cfg["service"]
+
+    def transcribe_chunk(self, chunk_path: str, settings: dict) -> str:
+        self._ensure_services(settings)
+
+        segment_seconds = settings.get("segment_seconds", 30)
+        confidence_threshold = settings.get("confidence_threshold", 0.7)
+        fallback_language = settings.get("fallback_language")
+        pass1_settings = settings.get("pass1", {}).get("settings", {})
+        pass2_settings = settings.get("pass2", {}).get("settings", {})
+
+        base_dir = self.output_dir or os.path.dirname(chunk_path)
+        segments_dir = os.path.join(base_dir, "two_pass_segments")
+
+        print(f"    [two-pass] Splitting into {segment_seconds}s segments...")
+        segment_paths = split_audio_by_duration(
+            chunk_path, segment_seconds, output_dir=segments_dir
+        )
+        print(f"    [two-pass] Created {len(segment_paths)} segment(s)")
+
+        # --- Pass 1: Language detection ---
+        print(f"    [two-pass] Pass 1: detecting language per segment...")
+        detections: list[dict] = []
+        for i, seg_path in enumerate(segment_paths):
+            result = self._pass1_service.transcribe_chunk_detailed(seg_path, pass1_settings)
+            lang = normalize_language_code(result.get("language"))
+            prob = result.get("language_probability")
+
+            if prob is not None and prob < confidence_threshold and fallback_language:
+                lang = fallback_language
+
+            if lang is None and fallback_language:
+                lang = fallback_language
+
+            detections.append({
+                "segment_index": i,
+                "segment_path": seg_path,
+                "detected_language": lang,
+                "language_probability": prob,
+                "pass1_text": result.get("text", ""),
+            })
+            print(f"      segment {i}: {lang} (prob={prob})")
+
+        lang_json_dir = os.path.join(segments_dir, "lang_cache")
+        os.makedirs(lang_json_dir, exist_ok=True)
+        self._last_detections = detections
+
+        for det in detections:
+            cache_path = os.path.join(lang_json_dir, f"segment_{det['segment_index']:03d}.lang.json")
+            with open(cache_path, "w", encoding="utf-8") as f:
+                json.dump(det, f, ensure_ascii=False, indent=2)
+
+        # --- Merge consecutive same-language segments ---
+        print(f"    [two-pass] Merging consecutive same-language segments...")
+        groups: list[dict] = []
+        for lang, group_iter in groupby(detections, key=lambda d: d["detected_language"]):
+            members = list(group_iter)
+            group_paths = [m["segment_path"] for m in members]
+
+            if len(group_paths) == 1:
+                merged_path = group_paths[0]
+            else:
+                merged_dir = os.path.join(segments_dir, "merged")
+                os.makedirs(merged_dir, exist_ok=True)
+                ext = os.path.splitext(group_paths[0])[1]
+                merged_path = os.path.join(merged_dir, f"group_{len(groups):03d}{ext}")
+                concat_audio_files(group_paths, merged_path)
+
+            groups.append({
+                "group_index": len(groups),
+                "language": lang,
+                "segment_indices": [m["segment_index"] for m in members],
+                "merged_path": merged_path,
+            })
+
+        print(f"    [two-pass] {len(groups)} group(s) after merging")
+        for g in groups:
+            print(f"      group {g['group_index']}: {g['language']} (segments {g['segment_indices']})")
+
+        # --- Pass 2: Transcribe with language hints ---
+        print(f"    [two-pass] Pass 2: transcribing with language hints...")
+        max_bytes = 24 * 1024 * 1024 if self._pass2_service.needs_splitting else None
+        transcripts: list[str] = []
+        for g in groups:
+            lang = g["language"]
+            if lang:
+                patched_settings = inject_language_hint(pass2_settings, lang, self._pass2_name)
+            else:
+                patched_settings = dict(pass2_settings)
+
+            merged = g["merged_path"]
+            if max_bytes and os.path.getsize(merged) > max_bytes:
+                sub_chunks = split_audio_by_duration(
+                    merged, segment_seconds,
+                    output_dir=os.path.join(segments_dir, f"group_{g['group_index']:03d}_splits"),
+                )
+                parts = []
+                for sc in sub_chunks:
+                    parts.append(self._pass2_service.transcribe_chunk(sc, patched_settings))
+                text = "\n".join(parts)
+            else:
+                text = self._pass2_service.transcribe_chunk(merged, patched_settings)
+
+            transcripts.append(text)
+            print(f"      group {g['group_index']} ({lang}): {len(text)} chars")
+
+        return "\n".join(transcripts)


### PR DESCRIPTION
## 概要

多言語音声の文字起こし精度を向上させるため、two-pass transcription機能を追加しました。

- 音声を30秒単位のセグメントに分割し、Pass 1で各セグメントの言語を自動検出
- 同一言語の連続セグメントをマージしてコンテキストを確保
- Pass 2で検出した言語ヒントを付与して再度文字起こしを実行
- 新規サービス `TwoPassService` として実装し、既存のsingle-passフローへの影響なし
- `config.yaml` に `fw-twopass` / `gpt4o-twopass` の2つの実験ランを追加

## 主な変更

- `services/two_pass.py`: TwoPassServiceの実装（言語検出→マージ→再文字起こし）
- `audio_splitter.py`: 時間ベース分割 `split_audio_by_duration()` とオーディオ結合 `concat_audio_files()` を追加
- `services/base.py`: `ChunkResult` に `detected_language` フィールド、`transcribe_chunk_detailed` メソッド追加
- `services/faster_whisper.py`, `services/elevenlabs.py`: 言語検出情報の抽出対応
- `comparison.py`: two-passラン向けに言語分布表示（例: `ja(8)/en(3)`）
- `.gitignore`: `transcribe_experiment/output/` を除外

## テスト手順

- [ ] `python run_experiment.py --dry-run` で設定解析の確認
- [ ] `python run_experiment.py --run-ids fw-twopass` でtwo-pass実験の実行
- [ ] `output/fw-twopass/meta.json` でセグメント別言語検出結果の確認
- [ ] 既存のsingle-passランが影響なく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)