### PR TITLE
運用向けシェルスクリプトを追加（Actions コスト分析 / axios 脆弱性チェック / ディスク分析）

### DIFF
--- a/analyze-actions-cost.sh
+++ b/analyze-actions-cost.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# analyze-actions-cost.sh — Break down elw-llc GitHub Actions cost.
+#
+# The org is on GitHub's enhanced billing platform: the classic
+# /orgs/{org}/settings/billing/actions endpoint is gone (HTTP 410), and the
+# /runs/{id}/timing endpoint reports total_ms: 0. So:
+#   - repo/SKU cost  -> /organizations/{org}/settings/billing/usage
+#   - per-workflow   -> Actions runs + jobs API (sum of per-job durations)
+#
+# Requires: gh (authenticated), jq, bc.
+#
+# Usage:
+#   ./analyze-actions-cost.sh sku       <year> <month>
+#   ./analyze-actions-cost.sh repos     <year> <month>
+#   ./analyze-actions-cost.sh workflows <owner/repo> <year> <month> [sample=15]
+#
+# Examples:
+#   ./analyze-actions-cost.sh repos 2026 7
+#   ./analyze-actions-cost.sh workflows elw-llc/drivesfa-management-server 2026 7
+set -euo pipefail
+
+ORG="${ORG:-elw-llc}"
+
+last_day() { # year month -> last day of month (handles leap Feb)
+  local y=$1 m=$((10#$2))
+  case $m in
+    1|3|5|7|8|10|12) echo 31 ;;
+    4|6|9|11)        echo 30 ;;
+    2) if (( y % 4 == 0 && (y % 100 != 0 || y % 400 == 0) )); then echo 29; else echo 28; fi ;;
+  esac
+}
+
+cmd_sku() { # year month
+  local y=$1 m=$2
+  echo "=== ${ORG} usage by product/SKU — ${y}-$(printf %02d "$m") (net USD) ==="
+  gh api "/organizations/${ORG}/settings/billing/usage?year=${y}&month=$((10#$m))" 2>/dev/null \
+  | jq -r '.usageItems
+      | group_by(.product + " / " + .sku)
+      | map({k:(.[0].product + " / " + .[0].sku), net:(map(.netAmount)|add)})
+      | sort_by(-.net)[] | "\((.net*100|round)/100)\t\(.k)"'
+}
+
+cmd_repos() { # year month
+  local y=$1 m=$2
+  echo "=== ${ORG} Actions Linux minutes by repo — ${y}-$(printf %02d "$m") ==="
+  printf "%10s  %10s  %s\n" "net_USD" "minutes" "repo"
+  gh api "/organizations/${ORG}/settings/billing/usage?year=${y}&month=$((10#$m))" 2>/dev/null \
+  | jq -r '[.usageItems[] | select(.product=="actions" and .sku=="Actions Linux")]
+      | group_by(.repositoryName)
+      | map({repo:.[0].repositoryName, min:(map(.quantity)|add), net:(map(.netAmount)|add)})
+      | sort_by(-.net)[] | "\((.net*100|round)/100)\t\(.min|round)\t\(.repo)"' \
+  | awk -F'\t' '{printf "%10s  %10s  %s\n", $1, $2, $3}'
+}
+
+cmd_workflows() { # owner/repo year month [sample]
+  local repo=$1 y=$2 m=$3 sample="${4:-15}"
+  local mm ld from to
+  mm=$(printf %02d "$m"); ld=$(last_day "$y" "$m")
+  from="${y}-${mm}-01"; to="${y}-${mm}-${ld}"
+  echo "=== ${repo} billable minutes by workflow — ${from}..${to} (sample=${sample}/workflow) ==="
+  printf "%-34s %6s %7s %12s %12s\n" "WORKFLOW" "runs" "sampled" "avg_min/run" "EST_min/mo"
+
+  # iterate active workflows
+  gh api "/repos/${repo}/actions/workflows" --jq '.workflows[] | select(.state=="active") | "\(.id)\t\(.name)"' 2>/dev/null \
+  | while IFS=$'\t' read -r wid name; do
+      local cnt; cnt=$(gh api "/repos/${repo}/actions/workflows/${wid}/runs?created=${from}..${to}&per_page=1" --jq '.total_count' 2>/dev/null || echo 0)
+      [ "${cnt:-0}" -eq 0 ] && continue
+      local tot=0 k=0 m_run
+      while read -r rid; do
+        [ -z "$rid" ] && continue
+        m_run=$(gh api "/repos/${repo}/actions/runs/${rid}/jobs?per_page=100" \
+          --jq '[.jobs[] | select(.completed_at!=null and .started_at!=null)
+                 | ((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601))
+                 | ((.+59)/60|floor)] | add // 0' 2>/dev/null || echo "")
+        if [ -n "$m_run" ]; then tot=$((tot+m_run)); k=$((k+1)); fi
+      done < <(gh api "/repos/${repo}/actions/workflows/${wid}/runs?status=completed&created=${from}..${to}&per_page=${sample}" --jq '.workflow_runs[].id' 2>/dev/null)
+      local avg=0 est=0
+      if [ "$k" -gt 0 ]; then avg=$(echo "scale=1; $tot/$k" | bc); est=$(echo "scale=0; $tot/$k*$cnt/1" | bc); fi
+      printf "%-34s %6s %7s %12s %12s\n" "$name" "$cnt" "$k" "$avg" "$est"
+    done
+}
+
+case "${1:-}" in
+  sku)       shift; cmd_sku "$@" ;;
+  repos)     shift; cmd_repos "$@" ;;
+  workflows) shift; cmd_workflows "$@" ;;
+  *) grep -E '^#( |!|$)' "$0" | sed 's/^# \{0,1\}//'; exit 1 ;;
+esac

--- a/check_axios_vuln.bat
+++ b/check_axios_vuln.bat
@@ -1,0 +1,129 @@
+@echo off
+chcp 65001 >nul 2>&1
+title axios 脆弱性チェッカー
+
+echo ===================================================
+echo   axios 脆弱性チェッカー
+echo   対象: axios@1.14.1, axios@0.30.4
+echo   (悪意あるリモートアクセスツール入りバージョン)
+echo ===================================================
+echo.
+
+set "FOUND=0"
+
+:: npm が使えるか確認
+where npm >nul 2>&1
+if errorlevel 1 (
+    echo [SKIP] npm が見つかりません。Node.js がインストールされていない場合、
+    echo        axios の影響を受ける可能性は低いです。
+    goto :RESULT
+)
+
+:: グローバルパッケージのチェック
+echo --- グローバルパッケージのチェック ---
+for /f "delims=" %%G in ('npm root -g 2^>nul') do set "GLOBAL_DIR=%%G"
+
+if exist "%GLOBAL_DIR%\axios\package.json" (
+    for /f "tokens=2 delims=:, " %%V in ('findstr /C:"\"version\"" "%GLOBAL_DIR%\axios\package.json"') do (
+        set "VER=%%~V"
+    )
+    call :CHECK_VERSION "グローバル" "%VER%"
+) else (
+    echo [OK] グローバルに axios はインストールされていません
+)
+
+if exist "%GLOBAL_DIR%\plain-crypto-js" (
+    echo [!!] 危険: グローバルに悪意ある依存関係 'plain-crypto-js' が見つかりました
+    set "FOUND=1"
+)
+echo.
+
+:: カレントディレクトリのチェック
+echo --- カレントディレクトリのチェック ---
+if exist "node_modules\axios\package.json" (
+    for /f "tokens=2 delims=:, " %%V in ('findstr /C:"\"version\"" "node_modules\axios\package.json"') do (
+        set "VER=%%~V"
+    )
+    call :CHECK_VERSION "カレントディレクトリ" "%VER%"
+) else (
+    echo [OK] カレントディレクトリに axios はありません
+)
+
+if exist "node_modules\plain-crypto-js" (
+    echo [!!] 危険: カレントディレクトリに悪意ある依存関係 'plain-crypto-js' が見つかりました
+    set "FOUND=1"
+)
+echo.
+
+:: ロックファイルのチェック
+echo --- ロックファイルのチェック ---
+for %%L in (package-lock.json yarn.lock pnpm-lock.yaml) do (
+    if exist "%%L" (
+        findstr /C:"plain-crypto-js" "%%L" >nul 2>&1
+        if not errorlevel 1 (
+            echo [!!] 危険: %%L に 'plain-crypto-js' への参照が見つかりました
+            set "FOUND=1"
+        )
+    )
+)
+echo.
+
+:: ユーザーフォルダ配下を広くスキャン
+echo --- ユーザーフォルダ配下のスキャン ---
+echo     ※ 少し時間がかかる場合があります。お待ちください...
+echo.
+
+for /f "delims=" %%F in ('dir /s /b "%USERPROFILE%\node_modules\axios\package.json" 2^>nul') do (
+    for /f "tokens=2 delims=:, " %%V in ('findstr /C:"\"version\"" "%%F"') do (
+        set "VER=%%~V"
+    )
+    call :CHECK_VERSION "%%F" "%VER%"
+)
+
+for /f "delims=" %%D in ('dir /s /b /ad "%USERPROFILE%\node_modules\plain-crypto-js" 2^>nul') do (
+    echo [!!] 危険: 'plain-crypto-js' が見つかりました: %%D
+    set "FOUND=1"
+)
+
+goto :RESULT
+
+:CHECK_VERSION
+set "LABEL=%~1"
+set "V=%~2"
+:: 前後の空白と引用符を除去
+set "V=%V: =%"
+set "V=%V:"=%"
+if "%V%"=="1.14.1" (
+    echo [!!] 危険: %LABEL% に悪意あるバージョン axios@1.14.1 が見つかりました
+    set "FOUND=1"
+) else if "%V%"=="0.30.4" (
+    echo [!!] 危険: %LABEL% に悪意あるバージョン axios@0.30.4 が見つかりました
+    set "FOUND=1"
+) else (
+    echo [OK] %LABEL%: axios@%V% ^(安全^)
+)
+goto :eof
+
+:RESULT
+echo.
+echo ===================================================
+if "%FOUND%"=="1" (
+    echo.
+    echo   [!!] 悪意あるバージョンが検出されました！
+    echo.
+    echo   エンジニアの方に以下を伝えてください:
+    echo     - axios@1.14.1 または axios@0.30.4 が検出された
+    echo     - plain-crypto-js というパッケージが見つかった
+    echo     - PCがマルウェアに感染している可能性がある
+    echo.
+    echo   すぐにネットワークから切断し、情報セキュリティ担当に連絡してください。
+    echo.
+) else (
+    echo.
+    echo   [OK] 問題は検出されませんでした。安全です。
+    echo.
+)
+echo ===================================================
+echo.
+echo 何かキーを押すと閉じます...
+pause >nul

--- a/check_axios_vuln.ps1
+++ b/check_axios_vuln.ps1
@@ -1,0 +1,209 @@
+# check_axios_vuln.ps1
+# axios の悪意あるバージョン (1.14.1, 0.30.4) がインストールされていないかチェックするスクリプト
+# 参考: https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan
+
+param(
+    [string]$Dir = ".",
+    [switch]$ScanAll,
+    [switch]$Help
+)
+
+$MaliciousVersions = @("1.14.1", "0.30.4")
+$MaliciousDep = "plain-crypto-js"
+$script:Found = $false
+
+function Write-Danger { param([string]$Msg) Write-Host "[!] 危険: $Msg" -ForegroundColor Red }
+function Write-Warning2 { param([string]$Msg) Write-Host "[!] 警告: $Msg" -ForegroundColor Yellow }
+function Write-Safe { param([string]$Msg) Write-Host "[OK] $Msg" -ForegroundColor Green }
+
+if ($Help) {
+    Write-Host "使い方: .\check_axios_vuln.ps1 [オプション]"
+    Write-Host "  -Dir <path>   チェック対象ディレクトリを指定 (デフォルト: カレントディレクトリ)"
+    Write-Host "  -ScanAll      ユーザープロファイル配下を全スキャン"
+    Write-Host "  -Help         ヘルプを表示"
+    exit 0
+}
+
+Write-Host "=== axios 脆弱性チェッカー ==="
+Write-Host "対象: axios@1.14.1, axios@0.30.4 (悪意あるRAT入りバージョン)"
+Write-Host "関連パッケージ: plain-crypto-js@4.2.1"
+Write-Host "-------------------------------------------"
+
+# 1. プロジェクトの node_modules をチェック
+function Test-Project {
+    param([string]$TargetDir)
+
+    Write-Host ""
+    Write-Host "--- プロジェクトのチェック ($TargetDir) ---"
+
+    $pkgJson = Join-Path $TargetDir "node_modules\axios\package.json"
+    if (Test-Path $pkgJson) {
+        $pkg = Get-Content $pkgJson -Raw | ConvertFrom-Json
+        $version = $pkg.version
+        if ($MaliciousVersions -contains $version) {
+            Write-Danger "$TargetDir に悪意あるバージョン axios@$version が見つかりました"
+            $script:Found = $true
+        } else {
+            Write-Safe "$TargetDir`: axios@$version (安全)"
+        }
+    }
+
+    $depDir = Join-Path $TargetDir "node_modules\$MaliciousDep"
+    if (Test-Path $depDir) {
+        Write-Danger "$TargetDir に悪意ある依存関係 '$MaliciousDep' が見つかりました"
+        $script:Found = $true
+    }
+}
+
+# 2. npm グローバルインストールをチェック
+function Test-NpmGlobal {
+    Write-Host ""
+    Write-Host "--- npm グローバルパッケージのチェック ---"
+
+    $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    if (-not $npmCmd) {
+        Write-Host "[SKIP] npm が見つかりません"
+        return
+    }
+
+    $globalDir = (npm root -g 2>$null).Trim()
+    if (-not $globalDir -or -not (Test-Path $globalDir)) {
+        Write-Host "[SKIP] npm グローバルディレクトリが見つかりません"
+        return
+    }
+
+    $axisPkg = Join-Path $globalDir "axios\package.json"
+    if (Test-Path $axisPkg) {
+        $pkg = Get-Content $axisPkg -Raw | ConvertFrom-Json
+        $version = $pkg.version
+        if ($MaliciousVersions -contains $version) {
+            Write-Danger "グローバルに悪意あるバージョン axios@$version がインストールされています"
+            $script:Found = $true
+        } else {
+            Write-Safe "グローバル: axios@$version (安全)"
+        }
+    } else {
+        Write-Safe "グローバルに axios はインストールされていません"
+    }
+
+    $globalDep = Join-Path $globalDir $MaliciousDep
+    if (Test-Path $globalDep) {
+        Write-Danger "グローバルに悪意ある依存関係 '$MaliciousDep' が見つかりました"
+        $script:Found = $true
+    }
+}
+
+# 3. npm キャッシュをチェック
+function Test-NpmCache {
+    Write-Host ""
+    Write-Host "--- npm キャッシュのチェック ---"
+
+    $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    if (-not $npmCmd) { return }
+
+    $cacheDir = (npm config get cache 2>$null).Trim()
+    if (-not $cacheDir -or -not (Test-Path $cacheDir)) { return }
+
+    foreach ($ver in $MaliciousVersions) {
+        $matches = Get-ChildItem -Path $cacheDir -Recurse -Filter "axios-$ver.tgz" -ErrorAction SilentlyContinue
+        if ($matches) {
+            Write-Warning2 "npm キャッシュに axios@$ver が残っています"
+            Write-Host "    削除するには: npm cache clean --force"
+            $script:Found = $true
+        }
+    }
+
+    $depMatches = Get-ChildItem -Path $cacheDir -Recurse -Directory -Filter $MaliciousDep -ErrorAction SilentlyContinue
+    if ($depMatches) {
+        Write-Warning2 "npm キャッシュに '$MaliciousDep' が残っています"
+        $script:Found = $true
+    }
+}
+
+# 4. ロックファイルのチェック
+function Test-Lockfiles {
+    param([string]$TargetDir)
+
+    Write-Host ""
+    Write-Host "--- ロックファイルのチェック ($TargetDir) ---"
+
+    $lockfiles = @("package-lock.json", "yarn.lock", "pnpm-lock.yaml")
+
+    foreach ($lockfile in $lockfiles) {
+        $path = Join-Path $TargetDir $lockfile
+        if (Test-Path $path) {
+            $content = Get-Content $path -Raw
+            foreach ($ver in $MaliciousVersions) {
+                if ($content -match "axios.*$ver") {
+                    Write-Danger "$lockfile に axios@$ver への参照が見つかりました"
+                    $script:Found = $true
+                }
+            }
+            if ($content -match $MaliciousDep) {
+                Write-Danger "$lockfile に '$MaliciousDep' への参照が見つかりました"
+                $script:Found = $true
+            }
+        }
+    }
+}
+
+# 5. システム全体をスキャン（オプション）
+function Search-System {
+    Write-Host ""
+    Write-Host "--- システム全体のスキャン (ユーザープロファイル配下) ---"
+    Write-Host "    ※ 時間がかかる場合があります..."
+
+    $userProfile = $env:USERPROFILE
+    $axiosPkgs = Get-ChildItem -Path $userProfile -Recurse -Depth 10 -Filter "package.json" -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match "node_modules[\\/]axios[\\/]package\.json$" }
+
+    foreach ($pkgFile in $axiosPkgs) {
+        $pkg = Get-Content $pkgFile.FullName -Raw | ConvertFrom-Json
+        $version = $pkg.version
+        $projectDir = Split-Path (Split-Path (Split-Path $pkgFile.FullName))
+        if ($MaliciousVersions -contains $version) {
+            Write-Danger "$projectDir に axios@$version が見つかりました"
+            $script:Found = $true
+        }
+    }
+
+    $depDirs = Get-ChildItem -Path $userProfile -Recurse -Depth 10 -Directory -Filter $MaliciousDep -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match "node_modules" }
+
+    foreach ($d in $depDirs) {
+        Write-Danger "'$MaliciousDep' が見つかりました: $($d.FullName)"
+        $script:Found = $true
+    }
+}
+
+# メイン処理
+Test-Project -TargetDir $Dir
+Test-Lockfiles -TargetDir $Dir
+Test-NpmGlobal
+Test-NpmCache
+
+if ($ScanAll) {
+    Search-System
+}
+
+Write-Host ""
+Write-Host "==========================================="
+if ($script:Found) {
+    Write-Host "[!] 悪意あるバージョンが検出されました！" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "対処手順:"
+    Write-Host "  1. 該当プロジェクトで安全なバージョンに更新:"
+    Write-Host "     npm install axios@1.14.0  (1.x系の場合)"
+    Write-Host "     npm install axios@0.30.3  (0.x系の場合)"
+    Write-Host "  2. node_modules を削除して再インストール:"
+    Write-Host "     Remove-Item -Recurse -Force node_modules; npm install"
+    Write-Host "  3. npm キャッシュをクリア:"
+    Write-Host "     npm cache clean --force"
+    Write-Host "  4. システムがRATに感染していないか確認:"
+    Write-Host "     - タスクマネージャーで不審なプロセスを確認"
+    Write-Host "     - netstat -ano で不審なネットワーク接続を確認"
+    exit 1
+} else {
+    Write-Safe "悪意ある axios バージョンは検出されませんでした"
+    exit 0
+}

--- a/check_axios_vuln.sh
+++ b/check_axios_vuln.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# check_axios_vuln.sh
+# axios の悪意あるバージョン (1.14.1, 0.30.4) がインストールされていないかチェックするスクリプト
+# 参考: https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan
+
+MALICIOUS_AXIOS_VERSIONS=("1.14.1" "0.30.4")
+MALICIOUS_DEP="plain-crypto-js"
+found=0
+
+echo "=== axios 脆弱性チェッカー ==="
+echo "対象: axios@1.14.1, axios@0.30.4 (悪意あるRAT入りバージョン)"
+echo "関連パッケージ: plain-crypto-js@4.2.1"
+echo "-------------------------------------------"
+
+# 1. カレントディレクトリの node_modules をチェック
+check_project() {
+    local dir="$1"
+    local pkg="$dir/node_modules/axios/package.json"
+
+    if [ -f "$pkg" ]; then
+        version=$(grep -o '"version": *"[^"]*"' "$pkg" | head -1 | grep -o '[0-9][^"]*')
+        for mal_ver in "${MALICIOUS_AXIOS_VERSIONS[@]}"; do
+            if [ "$version" = "$mal_ver" ]; then
+                echo "[!] 危険: $dir に悪意あるバージョン axios@$version が見つかりました"
+                found=1
+            fi
+        done
+        if [ "$found" -eq 0 ] 2>/dev/null; then
+            echo "[OK] $dir: axios@$version (安全)"
+        fi
+    fi
+
+    # plain-crypto-js の存在チェック
+    if [ -d "$dir/node_modules/$MALICIOUS_DEP" ]; then
+        echo "[!] 危険: $dir に悪意ある依存関係 '$MALICIOUS_DEP' が見つかりました"
+        found=1
+    fi
+}
+
+# 2. npm グローバルインストールをチェック
+check_npm_global() {
+    echo ""
+    echo "--- npm グローバルパッケージのチェック ---"
+    if command -v npm &>/dev/null; then
+        global_dir=$(npm root -g 2>/dev/null)
+        if [ -d "$global_dir/axios" ]; then
+            version=$(grep -o '"version": *"[^"]*"' "$global_dir/axios/package.json" | head -1 | grep -o '[0-9][^"]*')
+            for mal_ver in "${MALICIOUS_AXIOS_VERSIONS[@]}"; do
+                if [ "$version" = "$mal_ver" ]; then
+                    echo "[!] 危険: グローバルに悪意あるバージョン axios@$version がインストールされています"
+                    found=1
+                fi
+            done
+            if [ "$found" -eq 0 ] 2>/dev/null; then
+                echo "[OK] グローバル: axios@$version (安全)"
+            fi
+        else
+            echo "[OK] グローバルに axios はインストールされていません"
+        fi
+
+        if [ -d "$global_dir/$MALICIOUS_DEP" ]; then
+            echo "[!] 危険: グローバルに悪意ある依存関係 '$MALICIOUS_DEP' が見つかりました"
+            found=1
+        fi
+    else
+        echo "[SKIP] npm が見つかりません"
+    fi
+}
+
+# 3. npm cache をチェック
+check_npm_cache() {
+    echo ""
+    echo "--- npm キャッシュのチェック ---"
+    if command -v npm &>/dev/null; then
+        cache_dir=$(npm config get cache 2>/dev/null)
+        if [ -n "$cache_dir" ] && [ -d "$cache_dir" ]; then
+            for mal_ver in "${MALICIOUS_AXIOS_VERSIONS[@]}"; do
+                if find "$cache_dir" -path "*/axios/-/axios-${mal_ver}.tgz" 2>/dev/null | grep -q .; then
+                    echo "[!] 警告: npm キャッシュに axios@$mal_ver が残っています"
+                    echo "    削除するには: npm cache clean --force"
+                    found=1
+                fi
+            done
+            if find "$cache_dir" -path "*/$MALICIOUS_DEP/*" 2>/dev/null | grep -q .; then
+                echo "[!] 警告: npm キャッシュに '$MALICIOUS_DEP' が残っています"
+                found=1
+            fi
+        fi
+    fi
+}
+
+# 4. lock ファイルのチェック
+check_lockfiles() {
+    local dir="$1"
+    echo ""
+    echo "--- ロックファイルのチェック ($dir) ---"
+
+    for lockfile in "package-lock.json" "yarn.lock" "pnpm-lock.yaml"; do
+        local path="$dir/$lockfile"
+        if [ -f "$path" ]; then
+            for mal_ver in "${MALICIOUS_AXIOS_VERSIONS[@]}"; do
+                if grep -q "axios.*${mal_ver}" "$path" 2>/dev/null; then
+                    echo "[!] 危険: $lockfile に axios@$mal_ver への参照が見つかりました"
+                    found=1
+                fi
+            done
+            if grep -q "$MALICIOUS_DEP" "$path" 2>/dev/null; then
+                echo "[!] 危険: $lockfile に '$MALICIOUS_DEP' への参照が見つかりました"
+                found=1
+            fi
+        fi
+    done
+}
+
+# 5. システム全体をスキャン（オプション）
+scan_system() {
+    echo ""
+    echo "--- システム全体のスキャン (ホームディレクトリ配下) ---"
+    echo "    ※ 時間がかかる場合があります..."
+
+    while IFS= read -r pkg_json; do
+        dir=$(dirname "$(dirname "$pkg_json")")
+        version=$(grep -o '"version": *"[^"]*"' "$pkg_json" | head -1 | grep -o '[0-9][^"]*')
+        for mal_ver in "${MALICIOUS_AXIOS_VERSIONS[@]}"; do
+            if [ "$version" = "$mal_ver" ]; then
+                echo "[!] 危険: $dir に axios@$version が見つかりました"
+                found=1
+            fi
+        done
+    done < <(find "$HOME" -path "*/node_modules/axios/package.json" -maxdepth 10 2>/dev/null)
+
+    while IFS= read -r dep_dir; do
+        echo "[!] 危険: '$MALICIOUS_DEP' が見つかりました: $dep_dir"
+        found=1
+    done < <(find "$HOME" -path "*/node_modules/$MALICIOUS_DEP" -type d -maxdepth 10 2>/dev/null)
+}
+
+# メイン処理
+main() {
+    local scan_all=false
+    local target_dir="."
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --scan-all) scan_all=true; shift ;;
+            --dir) target_dir="$2"; shift 2 ;;
+            -h|--help)
+                echo "使い方: $0 [オプション]"
+                echo "  --dir <path>  チェック対象ディレクトリを指定 (デフォルト: カレントディレクトリ)"
+                echo "  --scan-all    ホームディレクトリ配下を全スキャン"
+                echo "  -h, --help    ヘルプを表示"
+                exit 0
+                ;;
+            *) echo "不明なオプション: $1"; exit 1 ;;
+        esac
+    done
+
+    echo ""
+    echo "--- プロジェクトのチェック ($target_dir) ---"
+    check_project "$target_dir"
+    check_lockfiles "$target_dir"
+    check_npm_global
+    check_npm_cache
+
+    if [ "$scan_all" = true ]; then
+        scan_system
+    fi
+
+    echo ""
+    echo "==========================================="
+    if [ "$found" -eq 1 ]; then
+        echo "[!] 悪意あるバージョンが検出されました！"
+        echo ""
+        echo "対処手順:"
+        echo "  1. 該当プロジェクトで安全なバージョンに更新:"
+        echo "     npm install axios@1.14.0  (1.x系の場合)"
+        echo "     npm install axios@0.30.3  (0.x系の場合)"
+        echo "  2. node_modules を削除して再インストール:"
+        echo "     rm -rf node_modules && npm install"
+        echo "  3. npm キャッシュをクリア:"
+        echo "     npm cache clean --force"
+        echo "  4. システムがRATに感染していないか確認"
+        echo "     - 不審なプロセスの確認: ps aux | grep -i crypto"
+        echo "     - 不審なネットワーク接続の確認: lsof -i -nP"
+        exit 1
+    else
+        echo "[OK] 悪意ある axios バージョンは検出されませんでした"
+        exit 0
+    fi
+}
+
+main "$@"

--- a/mac-disk-analyzer.sh
+++ b/mac-disk-analyzer.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== Mac Disk Usage Analyzer =="
+echo
+
+hr() {
+  echo "------------------------------------------------------------"
+}
+
+section() {
+  echo
+  hr
+  echo "$1"
+  hr
+}
+
+safe_du_top() {
+  local target="$1"
+  local depth="${2:-1}"
+  if [ -e "$target" ]; then
+    du -h -d "$depth" "$target" 2>/dev/null | sort -hr | head -n 30
+  else
+    echo "Not found: $target"
+  fi
+}
+
+section "1. Home directory top usage"
+du -h -d 1 ~ 2>/dev/null | sort -hr | head -n 30
+
+section "2. ~/Library breakdown"
+safe_du_top "$HOME/Library" 1
+
+section "3. ~/Library/Application Support breakdown"
+safe_du_top "$HOME/Library/Application Support" 1
+
+section "4. ~/Library/Caches breakdown"
+safe_du_top "$HOME/Library/Caches" 1
+
+section "5. ~/Developer breakdown"
+safe_du_top "$HOME/Developer" 2
+
+section "6. Common large dev caches"
+for p in \
+  "$HOME/.gradle" \
+  "$HOME/.m2" \
+  "$HOME/.npm" \
+  "$HOME/.pnpm-store" \
+  "$HOME/.cache" \
+  "$HOME/.ivy2" \
+  "$HOME/.coursier" \
+  "$HOME/.sdkman" \
+  "$HOME/.rustup" \
+  "$HOME/.cargo" \
+  "$HOME/.docker" \
+  "$HOME/.local" \
+  "$HOME/Downloads"
+do
+  if [ -e "$p" ]; then
+    du -sh "$p" 2>/dev/null
+  fi
+done | sort -hr
+
+section "7. Xcode / Simulator"
+for p in \
+  "$HOME/Library/Developer/Xcode/DerivedData" \
+  "$HOME/Library/Developer/Xcode/Archives" \
+  "$HOME/Library/Developer/CoreSimulator" \
+  "$HOME/Library/Developer/XCTestDevices"
+do
+  if [ -e "$p" ]; then
+    du -sh "$p" 2>/dev/null
+  fi
+done | sort -hr
+
+section "8. Docker Desktop related"
+for p in \
+  "$HOME/Library/Containers/com.docker.docker" \
+  "$HOME/Library/Group Containers/group.com.docker" \
+  "$HOME/.docker"
+do
+  if [ -e "$p" ]; then
+    du -sh "$p" 2>/dev/null
+  fi
+done | sort -hr
+
+if command -v docker >/dev/null 2>&1; then
+  echo
+  echo "[docker system df]"
+  docker system df || true
+
+  echo
+  echo "[largest docker volumes path if exists]"
+  find "$HOME/Library/Containers/com.docker.docker" -type d -name volumes 2>/dev/null | while read -r vdir; do
+    du -h -d 2 "$vdir" 2>/dev/null | sort -hr | head -n 20
+  done
+fi
+
+section "9. Top 30 large files in home directory (excluding obvious noisy system paths)"
+find ~ \
+  -path "$HOME/Library/Caches" -prune -o \
+  -path "$HOME/.Trash" -prune -o \
+  -type f -print0 2>/dev/null |
+  xargs -0 du -h 2>/dev/null |
+  sort -hr |
+  head -n 30
+
+section "10. node_modules directories"
+find ~ \
+  -path "$HOME/Library" -prune -o \
+  -type d -name node_modules -print0 2>/dev/null |
+  xargs -0 du -sh 2>/dev/null |
+  sort -hr |
+  head -n 50
+
+echo
+section "11. Suggested cleanup targets"
+cat <<'EOX'
+Check these first if they are large:
+- ~/Downloads
+- ~/Library/Application Support
+- ~/Library/Caches
+- ~/Library/Containers
+- ~/Library/Developer/Xcode/DerivedData
+- ~/Library/Developer/CoreSimulator
+- ~/.gradle
+- ~/.npm
+- ~/.pnpm-store
+- Docker unused images / volumes / build cache
+- old node_modules in unused repositories
+EOX
+
+echo
+echo "Done."

--- a/test_check_axios_vuln.sh
+++ b/test_check_axios_vuln.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# test_check_axios_vuln.sh
+# check_axios_vuln.sh の検出能力を検証するテストスクリプト
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check_axios_vuln.sh"
+TEST_DIR=$(mktemp -d)
+PASS=0
+FAIL=0
+
+cleanup() {
+    rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+run_test() {
+    local name="$1"
+    local dir="$2"
+    local expect_danger="$3"  # "detect" or "safe"
+
+    output=$("$CHECK_SCRIPT" --dir "$dir" 2>&1)
+    has_danger=$(echo "$output" | grep -c "危険")
+
+    if [ "$expect_danger" = "detect" ] && [ "$has_danger" -gt 0 ]; then
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    elif [ "$expect_danger" = "safe" ] && [ "$has_danger" -eq 0 ]; then
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $name"
+        echo "        期待: $expect_danger / 検出行数: $has_danger"
+        echo "        出力:"
+        echo "$output" | sed 's/^/        /'
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ダミーの node_modules 構造を作成するヘルパー
+make_axios() {
+    local base="$1"
+    local version="$2"
+    mkdir -p "$base/node_modules/axios"
+    cat > "$base/node_modules/axios/package.json" <<EOFPKG
+{
+  "name": "axios",
+  "version": "$version"
+}
+EOFPKG
+}
+
+make_plain_crypto() {
+    local base="$1"
+    mkdir -p "$base/node_modules/plain-crypto-js"
+    cat > "$base/node_modules/plain-crypto-js/package.json" <<EOFPKG
+{
+  "name": "plain-crypto-js",
+  "version": "4.2.1"
+}
+EOFPKG
+}
+
+make_lockfile() {
+    local base="$1"
+    local filename="$2"
+    local content="$3"
+    echo "$content" > "$base/$filename"
+}
+
+echo "=== check_axios_vuln.sh 検証テスト ==="
+echo ""
+
+# --- テスト1: 悪意ある axios@1.14.1 ---
+echo "[テスト1] axios@1.14.1 の検出"
+t1="$TEST_DIR/t1"
+mkdir -p "$t1"
+make_axios "$t1" "1.14.1"
+run_test "axios@1.14.1 を検出できる" "$t1" "detect"
+
+# --- テスト2: 悪意ある axios@0.30.4 ---
+echo "[テスト2] axios@0.30.4 の検出"
+t2="$TEST_DIR/t2"
+mkdir -p "$t2"
+make_axios "$t2" "0.30.4"
+run_test "axios@0.30.4 を検出できる" "$t2" "detect"
+
+# --- テスト3: 安全な axios@1.14.0 ---
+echo "[テスト3] axios@1.14.0 は安全"
+t3="$TEST_DIR/t3"
+mkdir -p "$t3"
+make_axios "$t3" "1.14.0"
+run_test "axios@1.14.0 を安全と判定" "$t3" "safe"
+
+# --- テスト4: 安全な axios@1.7.9 ---
+echo "[テスト4] axios@1.7.9 は安全"
+t4="$TEST_DIR/t4"
+mkdir -p "$t4"
+make_axios "$t4" "1.7.9"
+run_test "axios@1.7.9 を安全と判定" "$t4" "safe"
+
+# --- テスト5: plain-crypto-js の検出 ---
+echo "[テスト5] plain-crypto-js の検出"
+t5="$TEST_DIR/t5"
+mkdir -p "$t5"
+make_axios "$t5" "1.14.0"
+make_plain_crypto "$t5"
+run_test "plain-crypto-js を検出できる" "$t5" "detect"
+
+# --- テスト6: ロックファイルに悪意あるバージョンの参照 ---
+echo "[テスト6] package-lock.json 内の参照検出"
+t6="$TEST_DIR/t6"
+mkdir -p "$t6"
+make_lockfile "$t6" "package-lock.json" '{
+  "packages": {
+    "node_modules/axios": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.1.tgz"
+    }
+  }
+}'
+run_test "ロックファイル内の axios@1.14.1 参照を検出" "$t6" "detect"
+
+# --- テスト7: ロックファイルに plain-crypto-js ---
+echo "[テスト7] yarn.lock 内の plain-crypto-js 検出"
+t7="$TEST_DIR/t7"
+mkdir -p "$t7"
+make_lockfile "$t7" "yarn.lock" 'plain-crypto-js@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/plain-crypto-js/-/plain-crypto-js-4.2.1.tgz"'
+run_test "yarn.lock 内の plain-crypto-js を検出" "$t7" "detect"
+
+# --- テスト8: axios がインストールされていない ---
+echo "[テスト8] axios 未インストール"
+t8="$TEST_DIR/t8"
+mkdir -p "$t8"
+run_test "axios なしで安全と判定" "$t8" "safe"
+
+# --- 結果 ---
+echo ""
+echo "==========================================="
+echo "結果: $PASS 件成功 / $FAIL 件失敗 (全 $((PASS + FAIL)) 件)"
+if [ "$FAIL" -eq 0 ]; then
+    echo "全テスト合格!"
+else
+    echo "失敗したテストがあります"
+fi
+echo "==========================================="
+
+exit "$FAIL"


### PR DESCRIPTION
## 概要

日常運用で使っているシェルスクリプトを 4 種類（+ テスト 1 本）追加します。いずれも既存コードへの影響はなく、単体で実行できるスタンドアロンなスクリプトです。

## 追加したスクリプト

### `analyze-actions-cost.sh`
GitHub Actions のコストを SKU 別 / リポジトリ別 / ワークフロー別に集計します。

- 対象 org は環境変数 `ORG` で指定（デフォルト `elw-llc`）
- org が enhanced billing platform に移行済みのため、旧 `/orgs/{org}/settings/billing/actions` は 410、`/runs/{id}/timing` は `total_ms: 0` を返す。そのためコストは `/organizations/{org}/settings/billing/usage`、ワークフロー別はジョブ実行時間の合算から算出している
- 依存: `gh`（認証済み）, `jq`, `bc`

```
./analyze-actions-cost.sh sku       <year> <month>
./analyze-actions-cost.sh repos     <year> <month>
./analyze-actions-cost.sh workflows <owner/repo> <year> <month> [sample=15]
```

### `check_axios_vuln.sh` / `.ps1` / `.bat`
npm 上で改ざんされた axios（`1.14.1`, `0.30.4`）と、併せて配布された `plain-crypto-js` が入っていないかを検査します。macOS/Linux・PowerShell・cmd の 3 環境ぶんを用意しました。

- カレントプロジェクトの `node_modules`、npm のグローバルインストール、および周辺ディレクトリを走査
- 参考: https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan

### `test_check_axios_vuln.sh`
`check_axios_vuln.sh` の検出能力を検証するテスト。一時ディレクトリに危険バージョン / 安全バージョンのダミー `node_modules` を作り、期待どおり検出・非検出になるかを確認します。

### `mac-disk-analyzer.sh`
macOS のディスク使用量をセクション別（ホーム配下、キャッシュ、開発系ディレクトリなど）に集計して表示します。

## このPRに含めていないもの

作業ツリーには未追跡の `analyze_rps.py` / `analyze_rps_split.py` / `plot_processing_speed.py` / `microsoft_email_graph_api_experiment/` が残っていますが、別件の作業のため今回のコミットには含めていません。

## 確認方法

```bash
./test_check_axios_vuln.sh          # axios チェッカーのテストが通ること
./analyze-actions-cost.sh sku 2026 7
./mac-disk-analyzer.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zTtn2k1UmSD6LRwmtcb2q